### PR TITLE
TCP/UDP load balancer

### DIFF
--- a/k8s-udp-session-affanity/Dockerfile
+++ b/k8s-udp-session-affanity/Dockerfile
@@ -1,0 +1,10 @@
+FROM   python:3.11.6-alpine3.18
+
+ENV HOST=0.0.0.0
+ENV PORT=
+
+WORKDIR /usr/src/app
+COPY   . .
+
+CMD ["python", "app.py"]
+

--- a/k8s-udp-session-affanity/README.md
+++ b/k8s-udp-session-affanity/README.md
@@ -1,0 +1,13 @@
+Test script
+
+```python
+
+import socket
+
+UDP_PORT = 60002
+UDP_IP = '127.0.0.1'
+MESSAGE = 'ping'
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) # UDP
+sock.sendto(bytes(MESSAGE, "utf-8"), (UDP_IP, UDP_PORT))
+```

--- a/k8s-udp-session-affanity/README.md
+++ b/k8s-udp-session-affanity/README.md
@@ -1,3 +1,22 @@
+Build image
+
+```shell
+DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build -t a901002666/k8s-udp-session-affanity .
+```
+
+Run image
+
+```shell
+docker run -it --rm a901002666/k8s-udp-session-affanity
+```
+
+Send udp pack
+```shell
+echo 'nino' | nc -4u -w1 localhost 10080
+```
+
+
+
 Test script
 
 ```python
@@ -11,3 +30,6 @@ MESSAGE = 'ping'
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) # UDP
 sock.sendto(bytes(MESSAGE, "utf-8"), (UDP_IP, UDP_PORT))
 ```
+
+
+echo 'nino' | nc -u -w1 104.199.252.119 10080

--- a/k8s-udp-session-affanity/app.py
+++ b/k8s-udp-session-affanity/app.py
@@ -1,21 +1,31 @@
-#!/usr/bin/python3
+# UDP echo server
 import socket
-import os
 
-def loop_on_socket(s):
-  while True:
-    d, addr = s.recvfrom(1500)
-    print(d, addr)
-    s.sendto("ECHO: ".encode('utf8')+d, addr)
+HOST = "0.0.0.0"  # Standard loopback interface address (localhost)
+PORT = 10080  # Port to listen on (non-privileged ports are > 1023)
 
-if __name__ == "__main__":
-   # Instead of setting HOST to "0.0.0.0",
-   # we set HOST to the Load Balancer IP
-   HOST = os.environ.get('HOST') or '0.0.0.0'
-   PORT = os.environ.get('PORT') or 60002
-   sock = socket.socket(type=socket.SocketKind.SOCK_DGRAM)
-   sock.bind((HOST, PORT))
-   loop_on_socket(sock)
+s = socket.socket(socket.AF_INET , socket.SOCK_DGRAM)
+s.bind((HOST, PORT))
+print("Server started ...192.168.225..242:2222")
+print("Waiting for Client response...")
+while True:
+       print(s.recvfrom(1024))
 
-# 198.51.100.2 is the load balancer's IP address
-# You can also use the DNS name of the load balancer's IP address
+
+# # TCP echo server
+# import socket
+
+# HOST = "0.0.0.0"  # Standard loopback interface address (localhost)
+# PORT = 1935  # Port to listen on (non-privileged ports are > 1023)
+
+# with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+#     s.bind((HOST, PORT))
+#     s.listen()
+#     conn, addr = s.accept()
+#     with conn:
+#         print(f"Connected by {addr}")
+#         while True:
+#             data = conn.recv(1024)
+#             if not data:
+#                 break
+#             conn.sendall(data)

--- a/k8s-udp-session-affanity/app.py
+++ b/k8s-udp-session-affanity/app.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+import socket
+import os
+
+def loop_on_socket(s):
+  while True:
+    d, addr = s.recvfrom(1500)
+    print(d, addr)
+    s.sendto("ECHO: ".encode('utf8')+d, addr)
+
+if __name__ == "__main__":
+   # Instead of setting HOST to "0.0.0.0",
+   # we set HOST to the Load Balancer IP
+   HOST = os.environ.get('HOST') or '0.0.0.0'
+   PORT = os.environ.get('PORT') or 60002
+   sock = socket.socket(type=socket.SocketKind.SOCK_DGRAM)
+   sock.bind((HOST, PORT))
+   loop_on_socket(sock)
+
+# 198.51.100.2 is the load balancer's IP address
+# You can also use the DNS name of the load balancer's IP address

--- a/k8s-udp-session-affanity/client.py
+++ b/k8s-udp-session-affanity/client.py
@@ -1,0 +1,12 @@
+import socket
+
+#client program
+
+s = socket.socket(socket.AF_INET,socket.SOCK_DGRAM)
+
+while True:
+       ip ,port = input("Enter server ip address and port number :\n").split()
+       m = input("Enter data to send server: ")
+       res = s.sendto(m.encode(),("192.168.225.242",2222)) 
+       if res:
+          print("\nsuccessfully send")

--- a/k8s-udp-session-affanity/k8s/deployment.yaml
+++ b/k8s-udp-session-affanity/k8s/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: udp-app-srt
+  labels:
+    app: ingest-srs-v5-srt
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ingest-srs-v5
+      protocol: udp
+  template:
+    metadata:
+      labels:
+        app: ingest-srs-v5
+        protocol: udp
+    spec:
+      containers:
+      - name: app
+        image: a901002666/k8s-udp-session-affanity:udp
+        # env:
+        # - name: LB_IP
+        #   value: '10.8.7.210'
+        ports:
+        - name: srt
+          protocol: UDP
+          containerPort: 10080
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: udp-app-rtmp
+  labels:
+    app: ingest-srs-v5-rtmp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ingest-srs-v5
+      protocol: tcp
+  template:
+    metadata:
+      labels:
+        app: ingest-srs-v5
+        protocol: tcp
+    spec:
+      containers:
+      - name: app
+        image: a901002666/k8s-udp-session-affanity:tcp
+        # env:
+        # - name: LB_IP
+        #   value: '10.8.7.210'
+        ports:
+        - name: rtmp
+          containerPort: 1935

--- a/k8s-udp-session-affanity/k8s/service.yaml
+++ b/k8s-udp-session-affanity/k8s/service.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: default
+  name: ingest-srs-v5
+  labels:
+    app.kubernetes.io/name: livestream
+  # annotations:
+  #   cloud.google.com/l4-rbs: "enabled"
+spec:
+  type: NodePort
+  # externalTrafficPolicy: Cluster
+  selector:
+    app: ingest-srs-v5
+  ports:
+  - name: rtmp
+    protocol: TCP
+    port: 1935
+    targetPort: rtmp
+  - name: srt
+    protocol: UDP
+    port: 10080
+    targetPort: srt
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingest-srs-v5-external-tcp
+spec:
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: livestream
+  ports:
+  - port: 1935
+    targetPort: 1935
+    protocol: TCP
+  loadBalancerIP: "35.221.161.73"
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingest-srs-v5-external-udp
+spec:
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: livestream
+  ports:
+  - port: 10080
+    targetPort: 10080
+    protocol: UDP
+  loadBalancerIP: "35.221.161.73"


### PR DESCRIPTION
Goal:
- Serve different apps through GCP external loadbalancer support utp/tcp traffic simultaneously on different port.